### PR TITLE
fix the quantiles computation

### DIFF
--- a/lib/geostats.js
+++ b/lib/geostats.js
@@ -539,6 +539,19 @@ var geostats = function(a) {
 	};
 	
 
+	this.getQuantiles = function(nbClass) {
+		var tmp = this.sorted();
+		var quantiles = [];
+
+		var step = this.pop() / nbClass;
+		for (var i = 1; i < nbClass; i++) {
+			var qidx = Math.round(i*step+.5);
+			quantiles.push(tmp[qidx-1]); // zero-based
+		}
+
+		return quantiles;
+	};
+
 	/**
 	 * Quantile classification Return an array with bounds : ie array(0, 0.75,
 	 * 1.5, 2.25, 3);
@@ -548,29 +561,19 @@ var geostats = function(a) {
 		if (this._nodata())
 			return;
 
-		var a = Array();
 		var tmp = this.sorted();
+		var bounds = this.getQuantiles(nbClass);
+		bounds.unshift(tmp[0]);
 
-		var classSize = Math.round(this.pop() / nbClass);
-		var step = classSize;
-		var i = 0;
+		if (bounds[tmp.length - 1] !== tmp[tmp.length - 1])
+			bounds.push(tmp[tmp.length - 1]);
 
-		// we set first value
-		a[0] = tmp[0];
-
-		for (i = 1; i < nbClass; i++) {
-			a[i] = tmp[step];
-			step += classSize;
-		}
-		// we set last value
-		a.push(tmp[tmp.length - 1]);
-		
-		this.setBounds(a);
+		this.setBounds(bounds);
 		this.setRanges();
-		
+
 		// we specify the classification method
 		this.method = _t('quantile') + ' (' + nbClass + ' ' + _t('classes') + ')';
-		
+
 		return this.bounds;
 
 	};


### PR DESCRIPTION
Some bugs in getClassQuantile:

``` javascript
var v = [1,2,3,4,5,6,7,8,9,10,11,12];
var classifier = new geostats(v);

classifier.getClassQuantile(8)
// [ '1', '3', '5', '7', '9', '11', undefined, undefined, '12' ]

classifier.getClassQuantile(12)
// [ '1', '2', '3', '4', '5', '6', '7', '8', '9', '10', '11', '12', '12' ]
```

The meaning of the bounds is not clear for me. Are the bounds included in the class or not?

I dont want to break you api. I have added a method `getQuantiles` which returns the quantiles of the data, and `getClassQuantile` returns as before the bounds, ie the smallest data, the quantiles and the greatest data. On large datasets, the difference wont be noticeable.

With the patch:

``` javascript
classifier.getClassQuantile(8)
// [ '1', '2', '4', '5', '7', '8', '10', '11', '12' ]

classifier.getClassQuantile(12)
// [ '1', '2', '3', '4', '5', '6', '7', '8', '9', '10', '11', '12' ]

classifier.getClassQuantile(5)
// before: [ '1', '3', '5', '7', '9', '12' ]
// patch:  [ '1', '3', '5', '8', '10', '12' ]
```
