### PR TITLE
weird string conversion

### DIFF
--- a/lib/geostats.js
+++ b/lib/geostats.js
@@ -225,7 +225,7 @@ var geostats = function(a) {
 		for (var i = 0; i < a.length; i++) {
 			// check if the given value is a number
 			if (!isNaN(a[i]+"")) {
-				b[i] = parseFloat(a[i]).toFixed(this.precision);
+				b[i] = parseFloat(a[i].toFixed(this.precision));
 			} else {
 				b[i] = a[i];
 			}


### PR DESCRIPTION
I wonder why the returned values are string. I think there is a misplaced parenthesis in the `decimalFormat` method. You don't have to do a float conversion of `a[i]` which we can suppose to be already a number. But you want to convert to float `a[i].toFixed(this.precision)`
I may be wrong on this.
