### PR TITLE
Move mean calculation out of loop

### DIFF
--- a/lib/geostats.js
+++ b/lib/geostats.js
@@ -367,12 +367,12 @@ var geostats = function(a) {
 		
 		if (this.stat_variance  == null) {
 
-			var tmp = 0;
+			var tmp = 0, serie_mean = this.mean();
 			for (var i = 0; i < this.pop(); i++) {
-				tmp += Math.pow( (this.serie[i] - this.mean()), 2 );
+				tmp += Math.pow( (this.serie[i] - serie_mean), 2 );
 			}
 
-			this.stat_variance =  tmp /	this.pop();
+			this.stat_variance =  tmp / this.pop();
 			
 			if(round == true) {
 				this.stat_variance = Math.round(this.stat_variance * Math.pow(10,this.roundlength) )/ Math.pow(10,this.roundlength);


### PR DESCRIPTION
In the variance calculation, it recalculates the mean in each pass of the loop, leading to and On² execution time. Moved the invariant calculation outside the loop to make this On instead.