### PR TITLE
replace alert with console.warn for NodeJs compatibility

### DIFF
--- a/lib/geostats.js
+++ b/lib/geostats.js
@@ -458,7 +458,7 @@ var geostats = function(a) {
 		if (this.serie.length == 0) {
 			
 			if(this.silent) this.log("[silent mode] Error. You should first enter a serie!", true);
-			else alert("Error. You should first enter a serie!");
+			else throw new TypeError("Error. You should first enter a serie!");
 			return 1;
 		} else
 			return 0;
@@ -540,7 +540,7 @@ var geostats = function(a) {
 
 	    if(array[0] !== this.min() || array[array.length-1] !== this.max()) {
 	    	if(this.silent) this.log("[silent mode] " + t('Given bounds may not be correct! please check your input.\nMin value : ' + this.min() + ' / Max value : ' + this.max()), true);
-			else alert(_t('Given bounds may not be correct! please check your input.\nMin value : ' + this.min() + ' / Max value : ' + this.max()));
+			else throw new TypeError(_t('Given bounds may not be correct! please check your input.\nMin value : ' + this.min() + ' / Max value : ' + this.max()));
 	    	return; 
 	    }
 
@@ -718,7 +718,7 @@ var geostats = function(a) {
 
 	    if(this._hasNegativeValue() || this._hasZeroValue()) {
 	    	if(this.silent) this.log("[silent mode] " + _t('geometric progression can\'t be applied with a serie containing negative or zero values.'), true);
-			else alert(_t('geometric progression can\'t be applied with a serie containing negative or zero values.'));
+			else throw new TypeError(_t('geometric progression can\'t be applied with a serie containing negative or zero values.'));
 	    	return;
 	    }
 	    
@@ -1103,7 +1103,7 @@ var geostats = function(a) {
 			// check if some classes are not populated / equivalent of in_array function
 			if(this.counter.indexOf(0) !== -1) {
 		    	if(this.silent) this.log("[silent mode] " + _t("Geostats cannot apply 'discontinuous' mode to the getHtmlLegend() method because some classes are not populated.\nPlease switch to 'default' or 'distinct' modes. Exit!"), true);
-				else alert(_t("Geostats cannot apply 'discontinuous' mode to the getHtmlLegend() method because some classes are not populated.\nPlease switch to 'default' or 'distinct' modes. Exit!"));
+				else throw new TypeError(_t("Geostats cannot apply 'discontinuous' mode to the getHtmlLegend() method because some classes are not populated.\nPlease switch to 'default' or 'distinct' modes. Exit!"));
 				return;
 			}
 
@@ -1112,7 +1112,7 @@ var geostats = function(a) {
 		
 		if(ccolors.length < this.ranges.length) {
 			if(this.silent) this.log("[silent mode] " + _t('The number of colors should fit the number of ranges. Exit!'), true);
-			else alert(_t('The number of colors should fit the number of ranges. Exit!'));
+			else throw new TypeError(_t('The number of colors should fit the number of ranges. Exit!'));
 			return;
 		}
 		


### PR DESCRIPTION
hi!

This is great library! For a long time I was looking for such a solution like this, congrats!

I'm using **geostats** imported into a **NodeJs** application(a **MeteorJS** app) and when using the method **.setClassManually()** I'm occur in this error:
```
ReferenceError: alert is not defined
W20170901-21:39:27.247(-1)? (STDERR)     at [object Object].setClassManually (node_modules/geostats/lib/geostats.min.js:11:463)
```
I think that for good generic compatibility it is better not to use browser's own methods.

@simogeo I'm using this library within a geospatial data management platform that may be of interest to you. I would like to have an opionion and contributions from you, thank you for your time.
[keplerjs.io](http://keplerjs.io/)
[github.com/keplerjs](https://github.com/keplerjs)

Reference this library here:
[https://medium.com/keplerjs/geostatistical-keplerjs-plugin](https://medium.com/keplerjs/geostatistical-keplerjs-plugin-c7083a9318b4)

Cheers!
Stefano Cudini
[labs.easyblog.it](http://labs.easyblog.it/)