### PR TITLE
Fix the default legend style, so items are aligned vertically

### DIFF
--- a/lib/geostats.css
+++ b/lib/geostats.css
@@ -1,5 +1,6 @@
 .geostats-legend div {
-  margin:3px 10px 5px 10px
+  margin:3px 10px 5px 10px;
+  clear:left;
 }
 
 .geostats-legend-title {


### PR DESCRIPTION
Currently, with the default style, the elements of the legend are not aligned vertically.
<img width="199" alt="Captura de Pantalla 2019-10-08 a la(s) 21 01 52" src="https://user-images.githubusercontent.com/6061036/66425080-1d63ce80-ea0f-11e9-86f3-f7e10a22af98.png">

This PR fixes that:
<img width="152" alt="Captura de Pantalla 2019-10-08 a la(s) 21 01 29" src="https://user-images.githubusercontent.com/6061036/66425126-379dac80-ea0f-11e9-9336-4af705fc5c6c.png">