### PR TITLE
Added additional check to ArithmeticProgression calculation

### DIFF
--- a/lib/geostats.js
+++ b/lib/geostats.js
@@ -816,7 +816,9 @@ var geostats = function(a) {
 	    for (var i = 0; i <= nbClass; i++) {
 	    	if(i == 0) {
 	    		a[i] = tmpMin;
-	    	} else {
+			} else if(i == nbClass) {
+				a[i] = tmpMax;
+			} else {
 	    		a[i] = a[i-1] + (i * interval);
 	    	}
 	    }


### PR DESCRIPTION
When using ArithmeticProgression, there is a chance that the bounds calculation might miss a decimal place. Due to this ranges might not include all values. This was problematic in a certain project, because values that should have been inside the range were not.

The problem is visualized here:
![Screenshot from 2020-07-15 15-41-46](https://user-images.githubusercontent.com/25435795/87546247-e9aa8900-c6b1-11ea-8a2d-6321a1974e53.png)
All but the first value are calculated based on this equation: `a[i] = a[i-1] + (i * interval);`
In the image we can see the result of this calculation, and the value of the tmpMax.

The problem occured on these lines and to assure that the last value in bounds is correct, a simple else if clause will add the tmpMax to the last position instead of calculating it. Now similar to the first value, the last value also comes from a tmp variable.
```
for (var i = 0; i <= nbClass; i++) {
  if(i == 0) {
    a[i] = tmpMin;
   } else if(i == nbClass) {
    a[i] = tmpMax;
   } else {
    a[i] = a[i-1] + (i * interval);
   }
}
```






